### PR TITLE
Prevent starting the pipeline in empty environments (code-flow)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+-   Add a control gate for Kedro environments before starting the pipeline in Azure ML (https://github.com/getindata/kedro-azureml/issues/33)
 
 ## [0.3.1] - 2022-11-18
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     # "sphinx.ext.mathjax",
     "recommonmark",
     "sphinx_rtd_theme",
+    "sphinx_toolbox.collapse",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
 sphinx_rtd_theme
+sphinx-toolbox
 recommonmark

--- a/docs/source/03_quickstart.rst
+++ b/docs/source/03_quickstart.rst
@@ -120,6 +120,20 @@ which means that all of the files (including potentially sensitive ones!) will b
 
 Ensure ``code_directory: "."`` is set in the ``azureml.yml`` config file (it's set by default).
 
+
+.. collapse:: See example Dockerfile for code upload flow
+
+    .. code-block:: dockerfile
+
+        ARG BASE_IMAGE=python:3.9
+        FROM $BASE_IMAGE
+
+        # install project requirements
+        COPY src/requirements.txt /tmp/requirements.txt
+        RUN pip install -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
+
+\
+
 \Build the image:
 
 .. code:: console
@@ -141,6 +155,15 @@ Ensure ``code_directory: "."`` is set in the ``azureml.yml`` config file (it's s
 
 \
 Now you can re-use this environment and run the pipeline without the need to build the docker image again (unless you add some dependencies to your environment, obviously :-) ).
+
+.. warning::
+    | Azure Code upload feature has issues with empty folders as identified in `GitHub #33 <https://github.com/getindata/kedro-azureml/issues/33>`__, where empty folders or folders with empty files might not get uploaded to Azure ML, which might result in the failing pipeline.
+    | We recommend to:
+    | - make sure that Kedro environments you intent to use in Azure have at least one non-empty file specified
+    | - gracefully handle folder creation in your pipeline's code (e.g. if your code depends on an existence of some folder)
+    |
+    | The plugin will do it's best to handle some of the edge-cases, but the fact that some of your files might not be captured by Azure ML SDK is out of our reach.
+
 
 9.2. **If using docker image flow** (shown in the Quickstart video)
 

--- a/docs/spellcheck_exceptions.txt
+++ b/docs/spellcheck_exceptions.txt
@@ -104,3 +104,4 @@ jpg
 kedroazureml
 ly
 svg
+MLOps


### PR DESCRIPTION
* Prevents the pipeline to start in Azure ML code flow when empty Kedro envs are used (causes issues, because empty dirs are not getting uploaded to Azure), see #33 
* updated docs
