### PR TITLE
[WIP] Azureml v2-datasets local execution using fsspec

### DIFF
--- a/kedro_azureml/hooks.py
+++ b/kedro_azureml/hooks.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from kedro.extras.datasets.pickle import PickleDataSet
+from kedro.framework.hooks import hook_impl
+
+
+class AzureMLLocalRunHook:
+    """Hook class that allows local runs using AML datasets.
+
+    This class hooks in before pipeline run and does the following
+    given the pipeline that is to be run:
+    - change the dataset type to PickleDataSet
+      for each dataset that uses the `azureml://` protocol but is not an input
+      dataset to AzureMLLocalOutputDataset
+    """
+
+    @hook_impl
+    def before_pipeline_run(self, run_params, pipeline, catalog):
+        """Hook implementation to change dataset types to PickleDataSet
+        for local runs.
+
+        Args:
+            run_params: The parameters that are passed to the run command.
+            pipeline: The ``Pipeline`` object representing the pipeline to be run.
+            catalog: The ``DataCatalog`` from which to fetch data.
+        """
+        for dataset_name, dataset in catalog._data_sets.items():
+            if hasattr(dataset, "_protocol") and (dataset._protocol == "azureml"):
+                if dataset_name not in pipeline.inputs():
+                    project_path = Path(run_params["project_path"])
+                    new_filepath = (
+                        project_path / "data" / "local_run" / dataset._filepath.name
+                    )
+                    catalog._data_sets[dataset_name] = PickleDataSet(str(new_filepath))
+
+
+azureml_local_run_hook = AzureMLLocalRunHook()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,6 @@ pandas = "^1.4.3"
 
 [tool.poetry.plugins."kedro.project_commands"]
 "azureml" = "kedro_azureml.cli:commands"
+
+[tool.poetry.plugins."kedro.hooks"]
+"azure_local_run_hook" = "kedro_azureml.hooks:azureml_local_run_hook"


### PR DESCRIPTION
Hi all,

as mentioned by @tomasvanpottelbergh in #60 here is a proposal on enabling local execution of kedro pipelines that have aml datasets in the catalog as input and intermediate datasets. In essence it converts all AML datasets that are not root input datasets to a pipeline run into Pickle datasets and saves them in a `local-run` folder. It currently depends on "activating" `azureml-fsspec` in `kedro-datasets` see this comment: https://github.com/kedro-org/kedro-plugins/issues/200#issuecomment-1554256419 but other than that works for me in some local tests.

As mentioned in the other PR the guiding idea here is that during local execution there is only `read` and no `write` to AML datasets. This is to "guarantee" proper metadata flow and traceability. There would be an option to also upload from local runs but this would be more involved and should maybe be controlled via a CLI argument? Still probably prefer local executions not overwriting AML data.

This can easily be adopted to work with @tomasvanpottelbergh PR for AML folder datasets as well. Looking forward to some thoughts.