### PR TITLE
Support "deterministic" node tag

### DIFF
--- a/docs/source/03_quickstart.rst
+++ b/docs/source/03_quickstart.rst
@@ -364,6 +364,15 @@ Now we are able to reference this compute target in our kedro pipelines using ke
 When running our project, ``preprocess_companies`` and ``create_model_input_table``
 will be run on ``cpu-cluster-8`` while all other nodes are run on the default ``cpu-cluster``.
 
+Marking a node as deterministic
+------------------
+
+By default the plugin will mark all nodes of the Azure ML pipeline as non-deterministic, which 
+means that Azure ML will not reuse the results of the node if it has been run before.
+
+To mark a node as deterministic, you can simply add the ``deterministic`` tag to the node.
+This also implies the tag is reserved and cannot be used for compute types.
+
 Distributed training
 ------------------
 

--- a/kedro_azureml/generator.py
+++ b/kedro_azureml/generator.py
@@ -249,7 +249,7 @@ class AzureMLPipelineGenerator:
                 for name in node.outputs
             },
             code=self.config.azure.code_directory,
-            is_deterministic=False,  # TODO: allow setting this to true per node (e.g. by tags as for resources)
+            is_deterministic=("deterministic" in node.tags),
             **command_kwargs,
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,23 @@ def dummy_pipeline_compute_tag() -> Pipeline:
 
 
 @pytest.fixture()
+def dummy_pipeline_deterministic_tag() -> Pipeline:
+    return pipeline(
+        [
+            node(
+                identity,
+                inputs="input_data",
+                outputs="i2",
+                name="node1",
+                tags=["deterministic"],
+            ),
+            node(identity, inputs="i2", outputs="i3", name="node2"),
+            node(identity, inputs="i3", outputs="output_data", name="node3"),
+        ]
+    )
+
+
+@pytest.fixture()
 def dummy_plugin_config() -> KedroAzureMLConfig:
     return _CONFIG_TEMPLATE.copy(deep=True)
 


### PR DESCRIPTION
This PR enables setting the `is_deterministic` property of an Azure ML pipeline node by simply adding the tag `deterministic` to the Kedro pipeline node.

I had already added this before seeing #58. In my opinion having a single reserved keyword for this simplifies the implementation and usage. However, if there is a strong opinion to have the keyword configurable, I can adapt the PR accordingly.