### PR TITLE
Explicitly refer to `azure.code_directory` 💎

### DIFF
--- a/docs/source/03_quickstart.rst
+++ b/docs/source/03_quickstart.rst
@@ -166,11 +166,12 @@ This option is also shown in the video-tutorial above.
     | you will need to build and push the docker image to ACR again.
     | We recommend this option for CI/CD-automated MLOps workflows.
 
-10. Ensure that in the ``azureml.yml`` you have ``code_directory`` set to null, and ``docker.image`` is filled:
+10. Ensure that in the ``azureml.yml`` you have ``azure.code_directory`` set to null, and ``docker.image`` is filled:
 
     .. code:: yaml
 
-       code_directory: ~
+       azure:
+         code_directory: ~
        # rest of the azureml.yml file
        docker:
           image: your-container-registry.azurecr.io/kedro-azureml:latest

--- a/docs/source/03_quickstart.rst
+++ b/docs/source/03_quickstart.rst
@@ -216,7 +216,7 @@ can be removed from the ``Dockerfile``.
             COPY src/requirements.txt /tmp/requirements.txt
             RUN pip install -r /tmp/requirements.txt && rm -f /tmp/requirements.txt
 
-11. Ensure ``code_directory: "."`` is set in the ``azureml.yml`` config file (it's set if you've used ``--aml_env`` during ``init`` above).
+11. Ensure ``azure.code_directory: "."`` is set in the ``azureml.yml`` config file (it's set if you've used ``--aml_env`` during ``init`` above).
 
 
 


### PR DESCRIPTION
Be more explicit in the location and identation of `code_directory` 🌸

---

This is noted in the docs:

<img width="449" alt="Screenshot 2023-09-11 at 15 27 12" src="https://github.com/getindata/kedro-azureml/assets/744430/6c122ca2-ac28-46fb-aadb-701ccd499a99">

-> But actually the `code_directory` key should have identation. This PR fixes that.