### PR TITLE
added arguments to azuremldataasset for better control of output path

### DIFF
--- a/kedro_azureml/datasets/asset_dataset.py
+++ b/kedro_azureml/datasets/asset_dataset.py
@@ -77,6 +77,8 @@ class AzureMLAssetDataSet(AzureMLPipelineDataSet, AbstractVersionedDataSet):
         self,
         azureml_dataset: str,
         dataset: Union[str, Type[AbstractDataSet], Dict[str, Any]],
+        datastore: str = "workspaceblobstore",
+        azureml_root_dir: str = "kedro_azureml",  # maybe combine with root_dir?
         root_dir: str = "data",
         filepath_arg: str = "filepath",
         azureml_type: AzureMLDataAssetType = "uri_folder",
@@ -93,6 +95,8 @@ class AzureMLAssetDataSet(AzureMLPipelineDataSet, AbstractVersionedDataSet):
         """
         super().__init__(dataset=dataset, root_dir=root_dir, filepath_arg=filepath_arg)
 
+        self._azureml_root_dir = azureml_root_dir
+        self._datastore = datastore
         self._azureml_dataset = azureml_dataset
         self._version = version
         # 1 entry for load version, 1 for save version

--- a/kedro_azureml/generator.py
+++ b/kedro_azureml/generator.py
@@ -177,7 +177,11 @@ class AzureMLPipelineGenerator:
                     "AzureMLAssetDataSets with azureml_type 'uri_file' cannot be used as outputs"
                 )
             # TODO: add versioning
-            return Output(type=ds._azureml_type, name=ds._azureml_dataset)
+            return Output(
+                type=ds._azureml_type,
+                name=ds._azureml_dataset,
+                path=f"azureml://datastores/{ds._datastore}/paths/{ds._azureml_root_dir}/{ds.resolve_save_version()}",
+            )
         else:
             return Output(type="uri_folder")
 


### PR DESCRIPTION
@marrrcin @fdroessler @tomasvanpottelbergh 
Following issue #70, 
I propose this PR as a base for discussion, it is not meant to be merged as is for now. 

Main changes is that we specify a path in the Output of the command. 
It is important to note that this was only tested with a uri_folder outputting a single file. I think it may be worth it to test it with different types of uri_folders, especially datasets that write multiple files. 


Here is a summary of my experimentations: 

- If you don't specify a path in the output, it will be saved in the following folder in the default datastore: `azureml/<job_id>/<output_name>/`: this is currently the behavior in the plugin
- If you specify a path, it must be of the form `azureml://datastores/<datastore_name>/paths/<azureml_root_dir>` 

For this pull request, I decided to completely ignore the `root_dir` and use another argument instead (`azureml_root_dir`). This allows to have a local organisation of the files different from the organisation on azureml. 
I also added automatic versioning on save so we don't have the overwrite problem (it does not solve everything though, see below). 

With the following catalog.yml:

```yml
projects_train_dataset#web:
  type: pandas.CSVDataSet
  filepath: https://raw.githubusercontent.com/GokuMohandas/Made-With-ML/main/datasets/dataset.csv

projects_train_dataset#urifolder:
  type: kedro_azureml.datasets.AzureMLAssetDataSet
  versioned: True
  azureml_type: uri_folder
  azureml_dataset: projects_train_dataset
  root_dir: data/00_azurelocals/ # for local runs only
  dataset:
    type: pandas.CSVDataSet
    filepath: "projects_train_dataset.csv"
```

I tested the following pipeline 
```python 
from kedro.pipeline import Pipeline, node


def create_pipeline(**kwargs) -> Pipeline:
    return Pipeline(
        nodes=[
            node(
                func=lambda x: x,
                inputs="projects_train_dataset#web",
                outputs="projects_train_dataset#urifolder",
                name="create_train_dataasset",
            )
        ]
    )
```
which takes a csv as an input and saves it to the blob storage as output


When I do a local run, `kedro run`, data is saved to `data/00_azurelocals/projects_train_dataset/local/projects_train_dataset.csv`

When I do an azure run `kedro azureml run`, data is saved on azure in my datastore here `kedro_azureml/2023-09-14T14.12.29.983Z/projects_train_dataset.csv`. The Explore function of azureml works.

Important note: for now, the versioning solution I propose is not perfect. If two nodes run at the same time (for ex for train and test, both files will be saved in the same folder, for ex `kedro_azureml/2023-09-14T14.12.29.983Z/projects_train_dataset.csv` and `kedro_azureml/2023-09-14T14.12.29.983Z/projects_test_dataset.csv`. This leads to the impression that both files are part of the same dataset. Note that in theory, people should not put two different datasets in the same folder though... Maybe changing the default to include the dataset name would be enough. 


Finally, I also tried to use the dataasset as an input for both a local and azureml run. It works (for local runs, data is first downloaded to 
`data/00_azurelocals/projects_train_dataset/1/projects_train_dataset.csv` (here 1 is the dataset version). Note that this is not the same path as when the data asset is saved. That means that a local run using the data asset as output of a node and input of another will incorrectly use the initial data. However that this won't pose problems for runs on azureml. 


Please tell me what you think and what we should test next. 

 