### PR TITLE
Feature/export job name for cicd

### DIFF
--- a/kedro_azureml/cli.py
+++ b/kedro_azureml/cli.py
@@ -218,7 +218,7 @@ def init(
 )
 @click.option(
     "--export-pipeline-infos",
-    "export-pipeline-infos",
+    "export_pipeline_infos",
     is_flag=True,
     default=False,
     help="Set this flag to save the pipeline name to kedro_azureml_pipeline_infos.txt",

--- a/kedro_azureml/client.py
+++ b/kedro_azureml/client.py
@@ -43,7 +43,7 @@ class AzureMLPipelinesClient:
         config: AzureMLConfig,
         wait_for_completion=False,
         on_job_scheduled: Optional[Callable[[Job], None]] = None,
-    ) -> bool:
+    ) -> Job:
         with _get_azureml_client(self.subscription_id, config) as ml_client:
             assert (
                 cluster := ml_client.compute.get(
@@ -68,9 +68,9 @@ class AzureMLPipelinesClient:
             if wait_for_completion:
                 try:
                     ml_client.jobs.stream(pipeline_job.name)
-                    return True
+                    return pipeline_job
                 except Exception:
                     logger.exception("Error while running the pipeline", exc_info=True)
-                    return False
+                    return pipeline_job
             else:
-                return True
+                return pipeline_job


### PR DESCRIPTION
Hi @marrrcin 
Following issue #76,
do you think something like this is desirable or do you feel such an approach makes things too complex? 

The reason I want to make the pipeline name easy to retrieve is because when you launch a pipeline without using kedro-azureml, it is straightforward. 
Right now, to retrieve it, you need to store the output of kedro-azureml in a variable and do some sed work with the url, which seems a bit overkill though not impossible

On the other hand, saving the name to a file may not be ideal either. 

So the final question is: should retrieving the pipeline name be the responsibility of the developer (which can be done with a bit of work currently) or should the plugin provide an even easier way to retrieve it?

Thank you


