### PR TITLE
Make Framework an Enum

### DIFF
--- a/kedro_azureml/distributed/config.py
+++ b/kedro_azureml/distributed/config.py
@@ -1,9 +1,10 @@
 import json
 from dataclasses import asdict, dataclass
+from enum import Enum
 from typing import Optional, Union
 
 
-class Framework:
+class Framework(Enum):
     PyTorch = "PyTorch"
     TensorFlow = "TensorFlow"
     MPI = "MPI"

--- a/kedro_azureml/distributed/config.py
+++ b/kedro_azureml/distributed/config.py
@@ -4,7 +4,8 @@ from enum import Enum
 from typing import Optional, Union
 
 
-class Framework(Enum):
+# can be replaced by StrEnum starting from python 3.11
+class Framework(str, Enum):
     PyTorch = "PyTorch"
     TensorFlow = "TensorFlow"
     MPI = "MPI"


### PR DESCRIPTION
Following issue #80,
this PR makes Framework class inherit from Enum so that there is no type hint issue when using `@distributed_job` decorator.

